### PR TITLE
Add landing page route

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Run `npm install` inside `server/` and `client/` to install dependencies.
 
 Create a `.env` file based on `.env.example` and provide your Spotify credentials.
 After starting the backend visit `http://localhost:3000/auth/login` to authorize the application.
+Once authorized you will be redirected to `/`, which simply confirms that the backend is running.
 
 ### API Endpoints
 

--- a/client/README.md
+++ b/client/README.md
@@ -9,6 +9,5 @@ npm install
 npm start
 ```
 
-The client connects to the backend via Socket.IO and provides a simple interface
-to import playlists. Use the **Login with Spotify** link to authenticate before
-adding playlists. You can register and log in with the simple form on the main
+The client connects to the backend via Socket.IO and provides a simple interface to import playlists. Use the **Login with Spotify** link to authenticate before adding playlists. You can register and log in with the simple form on the main page.
+

--- a/server/README.md
+++ b/server/README.md
@@ -17,3 +17,4 @@ Create a `.env` file as shown in the repository root to configure the Spotify cr
 - `POST /playlists` – import a playlist by id
 - `POST /users/register` – register a new user
 - `POST /users/login` – login an existing user
+

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,11 @@ const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
 
+// simple landing page so `/` doesn't 404 after auth redirect
+app.get('/', (_req, res) => {
+  res.send('Hitster backend running');
+});
+
 const playlists = [];
 const users = [];
 let accessToken = null;


### PR DESCRIPTION
## Summary
- add a simple `/` route in the backend so the OAuth callback works
- document the landing page in the main README

## Testing
- `node --check server/index.js`
- `node --check client/app.js`
- `node --check client/server.js`


------
https://chatgpt.com/codex/tasks/task_e_684805c3ab64832eb8788fa152c24f3e