### PR TITLE
Fix client startup error

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "socket.io-client": "^4.7.2"
+    "socket.io-client": "^4.7.2",
+    "express": "^4.18.2"
   }
 }


### PR DESCRIPTION
## Summary
- include Express in the client dependencies

## Testing
- `./install.sh` *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68482176fa78832eb94b62fa849a0573