### PR TITLE
Implement install and session endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "express": "^4.18.2"
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@types/node": "^20.11.18"
   }
 }

--- a/backend/public/panel.html
+++ b/backend/public/panel.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Hitster Panel</title>
+</head>
+<body>
+  <h1>Hitster Control Panel</h1>
+  <p>The backend is running. Add your playlists and manage sessions here.</p>
+</body>
+</html>

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,14 +1,80 @@
 import express from 'express';
 import path from 'path';
+import fs from 'fs';
+import { loadDB, saveDB } from './storage';
+import { getAuthUrl, fetchPlaylist } from './spotify';
+import crypto from 'crypto';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+
+const publicDir = path.join(__dirname, 'public');
+const repoRoot = path.join(__dirname, '..', '..');
 
 app.get('/', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.use('/public', express.static(path.join(__dirname, 'public')));
+app.get('/install', (_req, res) => {
+  res.sendFile(path.join(publicDir, 'install.html'));
+});
+
+app.post('/install', (req, res) => {
+  const { clientId, clientSecret, redirectUri } = req.body;
+  const env = [
+    `SPOTIFY_CLIENT_ID=${clientId}`,
+    `SPOTIFY_CLIENT_SECRET=${clientSecret}`,
+    `SPOTIFY_REDIRECT_URI=${redirectUri}`,
+    `PORT=${PORT}`,
+    `CLIENT_PORT=4000`,
+    `DB_FILE=./data/data.json`
+  ].join('\n');
+  fs.writeFileSync(path.join(repoRoot, '.env'), env);
+
+  // initialize data directory
+  loadDB();
+  res.json({ status: 'installed' });
+});
+
+app.get('/panel', (_req, res) => {
+  res.sendFile(path.join(publicDir, 'panel.html'));
+});
+
+app.get('/login', (_req, res) => {
+  res.redirect(getAuthUrl());
+});
+
+app.get('/auth/callback', (req, res) => {
+  const code = req.query.code;
+  res.send(`Received code: ${code}`);
+});
+
+app.post('/api/playlists/:id', async (req, res) => {
+  const token = req.header('Authorization')?.replace('Bearer ', '');
+  if (!token) return res.status(401).json({ error: 'missing token' });
+  try {
+    const playlist = await fetchPlaylist(token, req.params.id);
+    const db = loadDB();
+    db.playlists.push(playlist);
+    saveDB(db);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    res.status(500).json({ error: 'failed to import playlist' });
+  }
+});
+
+app.post('/api/sessions', (_req, res) => {
+  const db = loadDB();
+  const id = crypto.randomUUID();
+  const session = { id, users: [] };
+  db.sessions.push(session);
+  saveDB(db);
+  res.json({ id });
+});
+
+app.use('/public', express.static(publicDir));
 
 app.listen(PORT, () => {
   console.log(`Server listening on ${PORT}`);

--- a/backend/src/spotify.ts
+++ b/backend/src/spotify.ts
@@ -1,0 +1,25 @@
+import querystring from 'querystring';
+
+export function getAuthUrl(): string {
+  const clientId = process.env.SPOTIFY_CLIENT_ID || '';
+  const redirectUri = process.env.SPOTIFY_REDIRECT_URI || '';
+  const scope = [
+    'playlist-read-private',
+    'user-read-private'
+  ].join(' ');
+  const params = querystring.stringify({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope
+  });
+  return `https://accounts.spotify.com/authorize?${params}`;
+}
+
+export async function fetchPlaylist(token: string, id: string): Promise<any> {
+  const res = await fetch(`https://api.spotify.com/v1/playlists/${id}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  if (!res.ok) throw new Error('Spotify request failed');
+  return res.json();
+}

--- a/backend/src/storage.ts
+++ b/backend/src/storage.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface Database {
+  users: any[];
+  playlists: any[];
+  sessions: any[];
+}
+
+const DATA_FILE = path.join(__dirname, '..', 'data', 'data.json');
+
+export function loadDB(): Database {
+  if (!fs.existsSync(DATA_FILE)) {
+    fs.mkdirSync(path.dirname(DATA_FILE), { recursive: true });
+    fs.writeFileSync(
+      DATA_FILE,
+      JSON.stringify({ users: [], playlists: [], sessions: [] }, null, 2)
+    );
+  }
+  return JSON.parse(fs.readFileSync(DATA_FILE, 'utf8')) as Database;
+}
+
+export function saveDB(db: Database): void {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(db, null, 2));
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -5,6 +5,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": ["es2020"],
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Summary
- serve install and panel pages from Express
- create web installer that writes `.env`
- add Spotify OAuth helpers
- store playlists and sessions in local DB
- provide session creation API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684868e4aa30832e8f1ffad105a49b7f